### PR TITLE
Use "-nox" emacs and vim package versions.

### DIFF
--- a/plugins/standard-packages-tasks/01-add-standard-packages
+++ b/plugins/standard-packages-tasks/01-add-standard-packages
@@ -2,7 +2,12 @@ packages+=('ca-certificates')
 packages+=('debconf-utils')
 packages+=('debian-goodies')
 packages+=('dnsutils')
-packages+=('zile')
+if [ "${codename}" = "wheezy" ]
+then
+    packages+=('emacs23-nox')
+else
+    packages+=('emacs-nox')
+fi
 packages+=('git')
 packages+=('hdparm')
 packages+=('less')
@@ -15,4 +20,4 @@ packages+=('ntp')
 packages+=('psmisc')
 packages+=('rsync')
 packages+=('sudo')
-packages+=('vim')
+packages+=('vim-nox')


### PR DESCRIPTION
Slight reduction to image size, and (more importantly) causes less dependency packages to be pulled in.
