### PR TITLE
Include getcert script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Consult the AWS documentation if any of these are unfamiliar to you.
 Next, you will need to set the path to your cloud certificate. Amazon
 includes this in the proprietary ec2-ami-tools package, and it is
 possible we need a license to redistribute it. Hence, you'll have to
-obtain that yourself.
+obtain that yourself either manually or using the included getcert
+script.
 
 ```
 export EUCALYPTUS_CERT="${HOME}/cert-ec2.pem"

--- a/getcert
+++ b/getcert
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# (c) 2015 SitePoint Pty. Ltd.
+# Adam Bolte <adam.bolte@sitepoint>
+#
+# Fetches ec2-ami-tools.zip to a temporary directory and extracts
+# cert-ec2.pem.
+
+set -e
+
+declare -r script_name="${0##*/}"
+declare -r ec2_ami_tools_url='http://s3.amazonaws.com/ec2-downloads/ec2-ami-tools.zip'
+declare -r ec2_ami_tools_zip='ec2-ami-tools.zip'
+declare -r ec2_ami_tools_zip_cert_path='ec2-ami-tools-*/etc/ec2/amitools/cert-ec2.pem'
+declare -r temp_dir="$(mktemp -d -p /tmp ${script_name}.XXXXXXXX)"
+declare -g download_mgr
+declare -g cert_path
+
+trap cleanup EXIT
+
+function cleanup()
+{
+    if [ -n "${temp_dir}" -a -d "${temp_dir}" ]
+    then
+        rm -rf "${temp_dir}"
+    fi
+}
+
+function parse_args()
+{
+    if [ "${#}" -ne 1 ]
+    then
+        print_usage 1>&2
+        exit 1
+    else
+        usage "${1}"
+    fi
+
+    cert_path="${1}"
+}
+
+function print_usage()
+{
+    echo "Usage: ${script_name} OUT_CERT_PATH"
+    echo "Try: ${script_name} cert-ec2.pem"
+}
+
+function usage()
+{
+    if [ "${1}" = '-h' ]
+    then
+        print_usage
+        exit 0
+    elif [ "${1}" = "--help" ]
+    then
+        print_usage
+        exit 0
+    fi
+}
+
+function dep_check()
+{
+    if command -v wget 1>/dev/null 2>&1
+    then
+        download_mgr='wget'
+    elif command -v curl 1>/dev/null 2>&1
+    then
+        download_mgr='curl'
+    else
+        echo "Error: Either curl or wget is required." 1>&2
+        exit 1
+    fi
+
+    if ! command -v unzip 1>/dev/null 2>&1
+    then
+        echo "Error: unzip is required." 1>&2
+        exit 1
+    fi
+
+    # If a path with a directory component is supplied as part of the
+    # argument, check the directory exists.
+    if echo "${cert_path}" | grep -q '/'
+    then
+        if [ ! -d "${cert_path%/*}" ]
+        then
+            echo "Error: directory ${cert_path%/*} not found." 1>&2
+            exit 1
+        fi
+    fi
+
+    # If a path already exists, complain. We probably don't want to
+    # force overwrite.
+    if [ -f "${cert_path}" ]
+    then
+        echo "Error: File already exists at '${cert_path}'." 1>&2
+        exit 1
+    fi
+
+    # It's possible that a directory was specified relative to the
+    # current working directory, and hence does not contain
+    # slashes. Check for this condition and assume the expected
+    # filename is that set in ${ec2_ami_tools_zip_cert_path}.
+    if [ -d "${cert_path}" ]
+    then
+        if [ -f "${cert_path}/${ec2_ami_tools_zip_cert_path##*/}" ]
+        then
+            {
+                echo -n "Error: File already exists at "
+                echo "'${cert_path}/${ec2_ami_tools_zip_cert_path##*/}'."
+            } 1>&2
+            exit 1
+        fi
+    fi
+}
+
+function fetch_zip()
+{
+    if [ "${download_mgr}" = 'wget' ]
+    then
+        wget -q -P "${temp_dir}" "${ec2_ami_tools_url}"
+    elif [ "${download_mgr}" = 'curl' ]
+    then
+        { cd "${temp_dir}" && curl -s -O "${ec2_ami_tools_url}" ; }
+    else
+        echo "Error: Download manager not supported by in fetch_zip()" 1>&2
+        exit 1
+    fi
+}
+
+function extract_zip()
+{
+    unzip -qq "${temp_dir}/${ec2_ami_tools_zip}" \
+        ${ec2_ami_tools_zip_cert_path} -d "${temp_dir}" && \
+        mv -f ${temp_dir}/${ec2_ami_tools_zip_cert_path} "${cert_path}"
+}
+
+parse_args ${@}
+dep_check
+fetch_zip
+extract_zip


### PR DESCRIPTION
Adds a script I wrote to download the ec2-ami-tools zip file to a temporary directory and extract the required cert-ec2.pem certificate automatically.

Saves a few minutes of mucking around every time I launch a new image builder instance, which was starting to get on my nerves.
