### PR TITLE
Add new grant-launch-permission plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ while retaining the power and flexibility of alternatives.
   stored safely in the same bucket, using your preferred directory
   structure!
 
+* The ``grant-launch-permission`` plugin. Automatically add launch
+  permissions to other AWS accounts for generated AMIs.
+
 * Support for more EC2 AMI types. Want Jessie HVM AMIs with a
   instance-store volume for the root device (for example)? We've got
   you covered.
@@ -126,13 +129,13 @@ script.
 export EUCALYPTUS_CERT="${HOME}/cert-ec2.pem"
 ```
 
-Lastly, if creating AMIs with instance-store volumes, you will need
-to set S3_BUCKET, and optionally also the CUSTOM_S3_PATH environment
-variables. S3_BUCKET is used to specify the S3 bucket (minus the
-s3:// prefix and any suffix path) you wish to bundle and upload your
-AMI to. If you do not specify CUSTOM_S3_PATH (and don't use the
-``move-s3-path`` plugin), your AMI will be registered here. However
-if you would rather have a more organised path like
+If creating AMIs with instance-store volumes, you will need to set
+S3_BUCKET, and optionally also the CUSTOM_S3_PATH environment
+variables. S3_BUCKET is used to specify the S3 bucket (minus the s3://
+prefix and any suffix path) you wish to bundle and upload your AMI
+to. If you do not specify CUSTOM_S3_PATH (and don't use the
+``move-s3-path`` plugin), your AMI will be registered here. However if
+you would rather have a more organised path like
 s3://my-company-region/debian-gnu_linux/jessie/x86_64/201506191210/
 where you can consolidate multiple AMIs into a single bucket, specify
 the bucket and path name for the CUSTOM_S3_PATH environment variable
@@ -158,16 +161,29 @@ export S3_BUCKET="my-temporary-build-bucket"
 export CUSTOM_S3_PATH="my-${EC2_REGION}-images/debian-gnu_linux/jessie"
 ```
 
-The last part of the setup process is (if generating instance-store
-AMIs using the move-s3-path plugin) to install and configure
-``s3cmd``. The s3cmd configure step will run you though a quick
-setup wizard, since the tool does not recognise the EC2_* environment
+The next part of the setup process (if generating instance-store AMIs
+using the move-s3-path plugin) is to install and configure
+``s3cmd``. The s3cmd configure step will run you though a quick setup
+wizard, since the tool does not recognise the EC2_* environment
 variables.
 
 ```
 apt-get install s3cmd
 s3cmd --configure
 ```
+
+If using the grant-launch-permission-tasks plugin, you will also need
+to set the following environment variable:
+
+```
+export LAUNCH_ACCOUNTS="1234-5678-9012 4321-8765-2190 9876-5432-1098"
+```
+
+This will allow the grant-launch-permission-tasks plugin to grant
+launch authorizatinon to accounts specified in the space-separated
+string (with optional dashes). This can come in hand when, for
+example, you want to share access to your AMIs with a separate account
+for staging or development.
 
 Getting the environment into a good state to generate images can take
 some time and it's easy to overlook something, so you may want to run

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
     * `grub.d/expand-volume` to be replaced by `cloud-initramfs-growroot`
     * `grub.d/generate-ssh-hostkeys` to be replaced by `cloud-init`.
     * Evaluate the possibility of adding cloud-initramfs-rescuevol to the generated initramfs.
-4. New plugin to automatically share images with other specific accounts.
-5. See if we can avoid using the custom grub.d file for paravirtual instances.
-6. Figure out what the problem is with isc-dhcp-client and see if it's fixable. We should use the default Debian packages wherever possible to improve consistency. Reportedly, isc-dhcp-client is only incompatible with Wheezy.
-7. Template support need not be EC2-specific.
+4. See if we can avoid using the custom grub.d file for paravirtual instances.
+5. Figure out what the problem is with isc-dhcp-client and see if it's fixable. We should use the default Debian packages wherever possible to improve consistency. Reportedly, isc-dhcp-client is only incompatible with Wheezy.
+6. Template support need not be EC2-specific.

--- a/envcheck
+++ b/envcheck
@@ -1,20 +1,23 @@
 #!/bin/bash
 
 declare -i exit_status=0
+declare -i essentials=0  # Print essentials in place message
+
 declare -i move_s3_path=3
+declare -i grant_launch_permission=1
 
 declare -r s3cfg="${HOME}/.s3cfg"
 
 for var in EC2_URL EUCALYPTUS_CERT EC2_CERT EC2_PRIVATE_KEY \
     AWS_ACCESS_KEY AWS_SECRET_KEY EC2_REGION EC2_USER_ID S3_BUCKET \
-    CUSTOM_S3_PATH
+    CUSTOM_S3_PATH LAUNCH_ACCOUNTS
 do
     # Check variable is not empty.
     if [ -z "${!var}" ]
     then
         echo "  unset ${var}"
         # Some missing variables are acceptable.
-        if ! [[ "${var}" =~ S3_BUCKET|CUSTOM_S3_PATH|EC2_URL ]]
+        if ! [[ "${var}" =~ EC2_URL|S3_BUCKET|CUSTOM_S3_PATH|LAUNCH_ACCOUNTS ]]
         then
             exit_status=1
         fi
@@ -36,6 +39,11 @@ do
         if [[ "${var}" =~ S3_BUCKET|CUSTOM_S3_PATH|EC2_URL ]]
         then
             move_s3_path=$(( --move_s3_path ))
+        # Cross of the required variable for the optional
+        # grant-launch-permission-tasks plugin.
+        elif [[ "${var}" =~ LAUNCH_ACCOUNTS ]]
+        then
+            grant_launch_permission=$(( --grant_launch_permission ))
         fi
     fi
 done
@@ -84,10 +92,22 @@ echo
 if [ "${exit_status}" -ne 0 ]
 then
     echo "Environment not ready."
-elif [ "${move_s3_path}" -ne 0 ]
-then
-    echo "Essentials are in place. move-s3-path is unavailable."
 else
-    echo "All systems green."
+    if [ ${move_s3_path} -ne 0 ]
+    then
+        echo "move-s3-path is unavailable."
+        essentials=1
+    fi
+    if [ ${grant_launch_permission} -ne 0 ]
+    then
+        echo "grant-launch-permission is unavailable."
+        essentials=1
+    fi
+    if [ ${essentials} -eq 1 ]
+    then
+        echo -e "\nEssentials are in place."
+    else
+        echo "All systems green."
+    fi
 fi
 exit ${exit_status}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -9,6 +9,8 @@ can run them via the `--plugin` option when bootstrapping. eg:
   Creates a user named 'admin', gives it sudo rights and disables the root login.
 * `build-metadata`
   Adds a build metadata output file to record the AMI and snapshot IDs for further scripting.
+* `grant-launch-permission`
+  Grants launch permission for the new AMI to a list of other AWS accounts.
 * `move_s3_path`
   Save multiple instance-backed AMIs to a single bucket by using sub-directories. Automatically appends sub-directories for architecture and timestamp.
 * `pause-before-umount`

--- a/plugins/grant-launch-permission
+++ b/plugins/grant-launch-permission
@@ -1,0 +1,5 @@
+insert_task_before ${TASK_PACKAGES} \
+    "${plugindir}/grant-launch-permission-tasks/check-inputs"
+
+insert_task_after ${TASK_CREATE_AMI} \
+    "${plugindir}/grant-launch-permission-tasks/run-euca-modify-image-attribute"

--- a/plugins/grant-launch-permission-tasks/check-inputs
+++ b/plugins/grant-launch-permission-tasks/check-inputs
@@ -1,0 +1,11 @@
+if [ -z "${LAUNCH_ACCOUNTS}" ]
+then
+    echo "Please set \$LAUNCH_ACCOUNTS before running this plug-in."
+    exit 1
+fi
+
+if ! command -v euca-modify-image-attribute >/dev/null 2>&1
+then
+    echo "The euca-modify-image-attribute command appears to be missing."
+    exit 1
+fi

--- a/plugins/grant-launch-permission-tasks/run-euca-modify-image-attribute
+++ b/plugins/grant-launch-permission-tasks/run-euca-modify-image-attribute
@@ -1,0 +1,8 @@
+declare account
+
+for account in $(echo ${LAUNCH_ACCOUNTS} | tr -d '-')
+do
+    echo euca-modify-image-attribute ${ami_id} -l -a ${account}
+done
+
+unset account


### PR DESCRIPTION
This functions similarly to the publish-ami plugin, only for select accounts (specified using the new `LAUNCH_ACCOUNTS` variable) rather than providing global launch privileges.
