### PR TITLE
Disable hwclock.sh on paravirtual instances only.

### DIFF
--- a/tasks/51-init-scripts
+++ b/tasks/51-init-scripts
@@ -9,6 +9,3 @@ do
     chmod 755 "${imagedir}/etc/init.d/${scriptname}"
     chroot "${imagedir}" insserv -d "${scriptname}"
 done
-
-# Inside Xen, CMOS clock is irrelevant, so save seconds at boot
-chroot "${imagedir}" insserv -r hwclock.sh

--- a/tasks/ec2/52-hwclock
+++ b/tasks/ec2/52-hwclock
@@ -1,0 +1,10 @@
+## hwclock
+#
+# Disable hardware clock checks on paravirtual instances that do not
+# provide hardware clock support. Apparently this can save seconds at
+# boot.
+
+if [ "${virt}" = 'paravirtual' ]
+then
+    chroot "${imagedir}" insserv -r hwclock.sh
+fi


### PR DESCRIPTION
/dev/rtc0 exists on HVM instances, and we should not change anything
from the defaults unnecessarily.
