### PR TITLE
Drop the euca-modify-image-attribute check.

### DIFF
--- a/plugins/grant-launch-permission-tasks/check-inputs
+++ b/plugins/grant-launch-permission-tasks/check-inputs
@@ -3,9 +3,3 @@ then
     echo "Please set \$LAUNCH_ACCOUNTS before running this plug-in."
     exit 1
 fi
-
-if ! command -v euca-modify-image-attribute >/dev/null 2>&1
-then
-    echo "The euca-modify-image-attribute command appears to be missing."
-    exit 1
-fi


### PR DESCRIPTION
If euca-modify-image-attribute is missing it will be installed later
as part of the euca2ools installation.
