### PR TITLE
Remove cached apt mirror listings

### DIFF
--- a/tasks/61-apt-cleanup
+++ b/tasks/61-apt-cleanup
@@ -8,5 +8,9 @@ chroot "${imagedir}" apt-get autoremove --purge
 # Erase downloaded archive files
 chroot "${imagedir}" apt-get clean
 
+# Avoid the possibility of including bad repository listings.
+# eg. https://serverfault.com/questions/722893/debian-mirror-hash-sum-mismatch
+rm -rf "${imagedir}/var/lib/apt/lists/"*
+
 # Enable the daemons again
 rm -rf "${imagedir}/usr/sbin/policy-rc.d"


### PR DESCRIPTION
I'm suspicious these are related to warnings I'm seeing when I run `apt-get update` on one of the AMIs I was using. In any case, these are not part of a package and are mirror-specific, so it feels cleaner to me to not include these in an AMI.