### PR TITLE
Stretch host updates

### DIFF
--- a/tasks/01-packages
+++ b/tasks/01-packages
@@ -31,4 +31,9 @@ then
 fi
 
 # Prevent urllib3 warnings about SOCKS support missing.
-host_packages+=('python-pysocks')
+if [ "${ID}" = "debian" ] && [ -n "${VERSION_ID}" ] && [ ${VERSION_ID} -le 8 ]
+then
+    host_packages+=('python-pysocks')
+else
+    host_packages+=('python-socks')
+fi

--- a/tasks/39-networking
+++ b/tasks/39-networking
@@ -1,10 +1,6 @@
 ## networking
 #
 
-# Delete the hostname file and DNS info, we get it from the ec2 dhcp
-# server.
-rm -f "${imagedir}/etc/resolv.conf"
-
 # Set /etc/hostname to localhost to avoid a "the specified hostname is
 # invalid" warning on boot.
 echo localhost > "${imagedir}/etc/hostname"

--- a/tasks/60-cleanup
+++ b/tasks/60-cleanup
@@ -17,3 +17,8 @@ fi
 rm -rf \
     "${imagedir}/var/log/{bootstrap,dpkg}.log" \
     "${imagedir}/tmp/"*
+
+# Delete resolvconf data as it will be obtained from the EC2 DHCP
+# server. This must be performed during the cleanup step so as to not
+# prevent packages from being downloaded.
+shred --remove "${imagedir}/etc/resolv.conf"


### PR DESCRIPTION
Getting the AMIs built (for https://github.com/sitepoint/salt-config/pull/380) required some small tweaks to debian-image-builder tasks since for the first time ever I was building them on a Stretch host.

I understand why the `python-pysocks` installation step failed, but was surprised I had never encountered the `/etc/resolv.conf` issue previously. Well, fixed now! :smile: 