### PR TITLE
Fix aws command if AWS_DEFAULT_OUTPUT is set

### DIFF
--- a/tasks/ec2/95-register-ami
+++ b/tasks/ec2/95-register-ami
@@ -29,6 +29,7 @@ then
     log "Registering an AMI"
 
     ami_id=$(aws ec2 register-image \
+             --output json \
              --name "${ami_name}" \
              --description "${description}" \
              --architecture "${machine_arch}" \
@@ -56,6 +57,7 @@ else
     log "Registering an AMI with the snapshot '${snapshot_id}'"
 
     ami_id=$(aws ec2 register-image \
+                 --output json \
                  --name "${ami_name}" \
                  --description "${description}" \
                  --architecture "${machine_arch}" \


### PR DESCRIPTION
Don't assume json is the default when parsing with the `jq` command. The user could have set the environment variable `AWS_DEFAULT_OUTPUT=text` for example.

In such cases, this fixes the error:
```
parse error: Invalid numeric literal at line 2, column 0
Unable to register an AMI.
```
when registration was most likely successful.