### PR TITLE
Implement support for EC2 Nitro instances

### DIFF
--- a/lib/utils
+++ b/lib/utils
@@ -228,14 +228,29 @@ function get_command_name
     echo ${command}
 }
 
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
+function is_nitro
+{
+    if mount | grep -q '^\/dev\/nvme0n1p[0-9]\ on\ \/\ type\ '
+    then
+        return 0
+    fi
+    return 1
+}
+
 function chroot_cmd
 {
-    local -r bind_args="$(for i in ${fs_device_path%1}*
+    local -r bind_args="$(
+        for i in ${block_device_path%1}*
         do
             echo -n \
                 "--bind=${i} " \
-                "--bind=${i}:$(echo ${i} | sed 's/\/dev\/xvd[a-z]/\/dev\/xvda/g') "
-        done)"
+                "--bind=${i}:$(echo ${i} | \
+                    sed -e 's/\/dev\/xvd[a-z]/\/dev\/xvda/g' \
+                        -e 's/\/dev\/nvme[0-9]n1p\([0-9]\+\)/\/dev\/xvda\1/g' \
+                        -e 's/\/dev\/nvme[0-9]n1/\/dev\/xvda/g') "
+        done
+    )"
 
     if command -v systemd-nspawn 1>/dev/null
     then

--- a/plugins/remount-tasks/remount-volume
+++ b/plugins/remount-tasks/remount-volume
@@ -44,7 +44,7 @@ logn "Reattaching the bootstrapped volume"
 aws ec2 attach-volume \
     --volume-id "${volume_id}" \
     --instance-id "${instance_id}" \
-    --device "/dev/xvd${device_letter}"
+    --device "/dev/xvd${device_letter}" >/dev/null
 
 # Wait until the volume is attached
 dotdot "test -b ${block_device_path} && echo attached"

--- a/plugins/remount-tasks/remount-volume
+++ b/plugins/remount-tasks/remount-volume
@@ -15,9 +15,29 @@ do
     fi
 done
 
+# Nitro hypervisors use NVMe EBS volumes. Check if our instance is
+# using that.
+#
+# Note: we still use device_letter (set in the above loop) later for
+# the aws ec2 attach-volume command.
+if ! is_nitro
+then
+    # As above, but for /dev/nvme... block device types. Such devices
+    # always start from 0, which is already known to be in use for
+    # root from the above if condition.
+    for device_number in {1..21}
+    do
+        block_device_path="/dev/nvme${device_number}n1"
+        if [ ! -b "${block_device_path}" ]
+        then
+            break
+        fi
+    done
+fi
+
 if [ -b "${block_device_path}" ]
 then
-    die "No free device letters found (tried xvdf to xvdz)!"
+    die "No free device letters found!"
 fi
 
 logn "Reattaching the bootstrapped volume"
@@ -32,7 +52,12 @@ dotdot "test -b ${block_device_path} && echo attached"
 # Set ${fs_device_path}
 if [ "${fs_device_path:$((${#fs_device_path} - 1)):1}" = 1 ]
 then
-    fs_device_path="${block_device_path}1"
+    if ! is_nitro
+    then
+        fs_device_path="${block_device_path}1"
+    else
+        fs_device_path="${block_device_path}p1"
+    fi
 else
     fs_device_path="${block_device_path}"
 fi

--- a/plugins/remount-tasks/remount-volume
+++ b/plugins/remount-tasks/remount-volume
@@ -44,7 +44,7 @@ logn "Reattaching the bootstrapped volume"
 aws ec2 attach-volume \
     --volume-id "${volume_id}" \
     --instance-id "${instance_id}" \
-    --device "/dev/xv${device_letter}"
+    --device "/dev/xvd${device_letter}"
 
 # Wait until the volume is attached
 dotdot "test -b ${block_device_path} && echo attached"

--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -9,7 +9,10 @@ declare -i attempt=24
 for device_letter in {f..z}
 do
     block_device_path="/dev/xvd${device_letter}"
-    [ ! -b "${block_device_path}" ] && break
+    if [ ! -b "${block_device_path}" ]
+    then
+        break
+    fi
 done
 
 if [ -b "${block_device_path}" ]

--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -15,9 +15,29 @@ do
     fi
 done
 
+# Nitro hypervisors use NVMe EBS volumes. Check if our instance is
+# using that.
+#
+# Note: we still use device_letter (set in the above loop) later for
+# the aws ec2 attach-volume command.
+if is_nitro
+then
+    # As above, but for /dev/nvme... block device types. Such devices
+    # always start from 0, which is already known to be in use for
+    # root from the above if condition.
+    for device_number in {1..21}
+    do
+        block_device_path="/dev/nvme${device_number}n1"
+        if [ ! -b "${block_device_path}" ]
+        then
+            break
+        fi
+    done
+fi
+
 if [ -b "${block_device_path}" ]
 then
-    die "No free device letters found (tried xvdf to xvdz)!"
+    die "No free device letters found!"
 fi
 
 # Wait until the volume has a status of 'available' before attempting
@@ -36,6 +56,7 @@ then
     die "It seems we were unable to create ${volume_id}."
 fi
 
+# attach-volume doesn't recognise /dev/nvme.* as a valid device name.
 aws ec2 attach-volume --volume-id "${volume_id}" \
     --instance-id "${instance_id}" \
     --device "/dev/xvd${device_letter}" >/dev/null
@@ -50,7 +71,12 @@ then
     parted -s -a optimal "${block_device_path}" mkpart primary ext4 1Mi 100%
     parted -s "${block_device_path}" set 1 boot on
     hdparm -z "${block_device_path}"
-    fs_device_path="${block_device_path}1"
+    if ! is_nitro
+    then
+        fs_device_path="${block_device_path}1"
+    else
+        fs_device_path="${block_device_path}p1"
+    fi
 else
     fs_device_path="${block_device_path}"
 fi

--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -42,7 +42,7 @@ fi
 
 # Wait until the volume has a status of 'available' before attempting
 # to attach to ensure success.
-while [ ${attempt} -ne 0 -a "$(aws --output json \
+while [ ${attempt} -gt 0 -a "$(aws --output json \
     ec2 describe-volumes \
     --volume-ids "${volume_id}" | \
     jq -e -r '.Volumes[0].State')" != "available" ]
@@ -51,7 +51,7 @@ do
     (( --attempt ))
 done
 
-if [ ${attempt} -eq 0 ]
+if [ ${attempt} -le 0 ]
 then
     die "It seems we were unable to create ${volume_id}."
 fi

--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -4,8 +4,8 @@
 
 declare -i attempt=24
 
-# Get a random device letter, we will hang forever if we try to attach
-# a volume to an already mapped device.
+# Get a random device letter, we will hang forever if we try
+# to attach a volume to an already mapped device.
 for device_letter in {f..z}
 do
     block_device_path="/dev/xvd${device_letter}"

--- a/tasks/ec2/11-attach-volume
+++ b/tasks/ec2/11-attach-volume
@@ -2,7 +2,7 @@
 #
 # Attach the EBS volume, and partition if necessary.
 
-declare -i attempt=12
+declare -i attempt=24
 
 # Get a random device letter, we will hang forever if we try to attach
 # a volume to an already mapped device.


### PR DESCRIPTION
Specifically, this adds support for generating AMIs on EC2 Nitro AMIs. EBS-backed AMIs built by running Debian Image Builder on a standard non-Nitro instance are also compatible with Nitro instance types, and vice-versa.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances

7ac75a2 was added because I was somehow able to trigger an infinite loop in that code block. I can't see how that could have happened, so I just tightened up the checks.